### PR TITLE
Nil can be used as the default value of an initializer argument

### DIFF
--- a/lib/initializer/controls/default_values.rb
+++ b/lib/initializer/controls/default_values.rb
@@ -9,7 +9,8 @@ module Initializer
           rw(:another_attr, Attributes.another_attr),
           na(:no_attr, Attributes.no_attr),
           rw(:lazy_attr, lazy('1 + 1')),
-          r(:symbol_attr, :some_symbol)
+          r(:symbol_attr, :some_symbol),
+          a(:nil_default_attr, nil)
       end
 
       def self.example

--- a/lib/initializer/parameter.rb
+++ b/lib/initializer/parameter.rb
@@ -21,10 +21,8 @@ module Initializer
       end
     end
 
-    def self.build(name, visibility, default=nil)
+    def self.build(name, visibility, default=:no_default_value)
       instance = new(name, visibility)
-
-      default ||= :no_default_value
 
       unless default == :no_default_value
         default = build_default_value(default)
@@ -40,6 +38,8 @@ module Initializer
       unless default_value.respond_to?(:code_fragment)
         if [String, Symbol].include?(result.class)
           result = StringDefaultValue.new(result.to_s)
+        elsif result.nil?
+          result = NilDefaultValue
         else
           result = Statement.new(result)
         end
@@ -74,6 +74,12 @@ module Initializer
 
       def code_fragment
         "'#{@value}'"
+      end
+    end
+
+    module NilDefaultValue
+      def self.code_fragment
+        "nil"
       end
     end
 

--- a/test/spec/default_values.rb
+++ b/test/spec/default_values.rb
@@ -7,5 +7,6 @@ context "Initializer Generated with Default Values" do
     assert(example.initialized?(check_no_attr: true))
     assert(example.lazy_attr == 2)
     assert(example.symbol_attr == :some_symbol.to_s)
+    assert(example.nil_default_attr == nil)
   end
 end


### PR DESCRIPTION
Given the following class:

``` ruby
class SomeClass
  attr_writer :some_attr

  def initialize(some_attr=nil)
    @some_attr = some_attr
  end

  def some_attr
    @some_attr ||= some_default_value
  end
end
```

The `initializer` library ought to be able to shorten the implementation like this:

```
class SomeClass
  initializer w(:some_attr, nil)

  def some_attr
    @some_attr ||= some_default_value
  end
end
```

I believe this used to work, but at some point this regressed. If you supply `nil` as the default value, the eventual `Parameter` object that is constructed by the visibility macro ends up nil coalescing the default `nil` into a `:no_default_value`. This PR fixes that regression.
